### PR TITLE
Add ESP32 library planning notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,13 @@
 # TMC5240-Libary
+
+This repository aims to provide a dedicated ESP32 library for interfacing with the TMC5240 stepper motor driver. The implementation will rely on the official **TMC-API** and will expose Arduino style C++ classes for easy integration in ESP32 projects.
+
+## Goals
+- Wrap the TMC-API to provide simple initialization and configuration helpers for the TMC5240
+- Allow reading and writing of all driver registers
+- Provide high level movement commands (e.g. position and velocity control)
+- Offer simple status and diagnostics functions
+- Include usage examples targeting the ESP32 toolchain
+
+The project currently contains only notes and collected documentation. See the `To Do` file for the planned feature list.
+

--- a/To Do
+++ b/To Do
@@ -1,1 +1,24 @@
+# To Do
+
+This file collects ideas for the upcoming ESP32 TMC5240 library built on top of the TMC-API. These points describe the planned functionality.
+
+## Core functions
+- `begin()` - initialize SPI/I2C interfaces and the TMC5240 driver
+- `configureDriver()` - apply default configuration parameters
+- `setMotorCurrent(mA)` - adjust motor current limits
+- `setMicrosteps(steps)` - configure microstep resolution
+- `enableDriver()` / `disableDriver()` - control the enable pin
+- `moveTo(targetPosition)` - absolute positioning
+- `moveBy(deltaSteps)` - relative positioning
+- `setVelocity(velocity)` - set target velocity
+- `stop()` - quick stop the motor
+- `readRegister(address)` / `writeRegister(address, value)` - low level register access
+- `getPosition()` - read the actual position counter
+- `getStatus()` - fetch driver status and error flags
+- `checkErrors()` - convenience function to query fault conditions
+
+## Other tasks
+- Provide examples demonstrating basic motion, configuration and diagnostics
+- Add CMake/Arduino build support for ESP32
+- Write documentation and usage instructions in the README
 


### PR DESCRIPTION
## Summary
- expand README with goals for the ESP32 TMC5240 library
- outline functions and tasks in `To Do`

## Testing
- `make test` *(fails: No rule to make target)*
- `npm test` *(fails: could not read package.json)*
- `cargo test` *(fails: could not find `Cargo.toml`)*

------
https://chatgpt.com/codex/tasks/task_e_6846ae4f01a483248f67ce25843f9d29