### PR TITLE
Clarify SPI-only library usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,15 @@
 # TMC5240-Libary
 
-This repository aims to provide a dedicated ESP32 library for interfacing with the TMC5240 stepper motor driver. The implementation will rely on the official **TMC-API** and will expose Arduino style C++ classes for easy integration in ESP32 projects.
+This repository aims to provide a dedicated ESP32 library for interfacing with the TMC5240 stepper motor driver **via SPI**. The implementation will rely on the official **TMC-API** and will expose Arduino style C++ classes for easy integration in ESP32 projects. Support for UART communication is currently out of scope.
 
 ## Goals
-- Wrap the TMC-API to provide simple initialization and configuration helpers for the TMC5240
+- Wrap the TMC-API to provide simple initialization and configuration helpers for the TMC5240 over SPI
 - Allow reading and writing of all driver registers
 - Provide high level movement commands (e.g. position and velocity control)
 - Offer simple status and diagnostics functions
 - Include usage examples targeting the ESP32 toolchain
+
+At this stage the library focuses solely on SPI communication with the driver. UART mode is not supported yet.
 
 The project currently contains only notes and collected documentation. See the `To Do` file for the planned feature list.
 

--- a/To Do
+++ b/To Do
@@ -1,9 +1,10 @@
 # To Do
 
 This file collects ideas for the upcoming ESP32 TMC5240 library built on top of the TMC-API. These points describe the planned functionality.
+The initial implementation will communicate with the driver exclusively via SPI. UART support is currently not planned.
 
 ## Core functions
-- `begin()` - initialize SPI/I2C interfaces and the TMC5240 driver
+- `begin()` - initialize the SPI interface and the TMC5240 driver (UART is not planned)
 - `configureDriver()` - apply default configuration parameters
 - `setMotorCurrent(mA)` - adjust motor current limits
 - `setMicrosteps(steps)` - configure microstep resolution
@@ -31,9 +32,9 @@ This file collects ideas for the upcoming ESP32 TMC5240 library built on top of 
 - `tmc5240_fieldExtract(data, field)` - extract field from data
 - `tmc5240_fieldUpdate(data, field, value)` - modify field in place
 - `tmc5240_readWriteSPI(icID, *data, length)` - SPI transfer callback
-- `tmc5240_readWriteUART(icID, *data, writeLen, readLen)` - UART transfer callback
+- `tmc5240_readWriteUART(icID, *data, writeLen, readLen)` - UART transfer callback (not used in this library)
 - `tmc5240_getBusType(icID)` - get active bus
-- `tmc5240_getNodeAddress(icID)` - get node address for UART
+- `tmc5240_getNodeAddress(icID)` - get node address for UART (unused)
 - `tmc_ramp_init(ramp, type)` - initialize generic ramp
 - `tmc_ramp_compute(ramp, type, delta)` - update ramp step
 - `tmc_ramp_get_rampVelocity(ramp, type)` - current ramp velocity


### PR DESCRIPTION
## Summary
- mention that the library focuses on SPI in README
- note the SPI-only scope in TODO and mark UART items unused

## Testing
- `make test` *(fails: No rule to make target)*

------
https://chatgpt.com/codex/tasks/task_e_6846b117183883248e31a3b433767d1d